### PR TITLE
Shorten code

### DIFF
--- a/main.py
+++ b/main.py
@@ -2,11 +2,7 @@ import discord
 from discord.ext import commands
 import os
 
-intents = discord.Intents.default()
-client = commands.Bot(command_prefix="d!", intents=intents, case_insensitive=True)
-
-client.remove_command('help')
-
+client = commands.Bot(command_prefix="d!", case_insensitive=True, help_command=None)
 
 @client.event
 async def on_command_error(ctx, error):


### PR DESCRIPTION
Intents.default are enabled by default, no need to specify them. I must say, I appreciate you not unnecessarily enabling the privileged intents!
Also, the help_command kwarg is the recommended way to remove the help command.